### PR TITLE
Make DateTime mutable again

### DIFF
--- a/lib/Horde_Date.php
+++ b/lib/Horde_Date.php
@@ -1097,6 +1097,9 @@ class Horde_Date
     protected function _initializeFromObject($date)
     {
         if ($date instanceof DateTime || $date instanceof DateTimeImmutable) {
+            if ($date instanceof DateTimeImmutable) {
+                $date = DateTime::createFromImmutable( $date );
+            }
             $this->_year  = (int)$date->format('Y');
             $this->_month = (int)$date->format('m');
             $this->_mday  = (int)$date->format('d');

--- a/lib/Horde_Date_Recurrence.php
+++ b/lib/Horde_Date_Recurrence.php
@@ -1566,6 +1566,9 @@ class Horde_Date_Recurrence
         if (isset($hash['exclusion'])) {
             foreach ($hash['exclusion'] as $exception) {
                 if ($exception instanceof DateTime || $exception instanceof DateTimeImmutable) {
+                    if ($exception instanceof DateTimeImmutable) {
+                        $exception = DateTime::createFromImmutable( $exception );
+                    }
                     $this->exceptions[] = $exception->format('Ymd');
                 }
             }
@@ -1574,6 +1577,9 @@ class Horde_Date_Recurrence
         if (isset($hash['complete'])) {
             foreach ($hash['complete'] as $completion) {
                 if ($exception instanceof DateTime || $exception instanceof DateTimeImmutable) {
+                    if ($exception instanceof DateTimeImmutable) {
+                        $exception = DateTime::createFromImmutable( $exception );
+                    }
                     $this->completions[] = $completion->format('Ymd');
                 }
             }

--- a/lib/libcalendaring_itip.php
+++ b/lib/libcalendaring_itip.php
@@ -467,6 +467,9 @@ class libcalendaring_itip
                             if ($key == 'allday') {
                                 $event[$key] = $event[$key] == 'true';
                             }
+                            if ($existing[$key] instanceof DateTimeImmutable) {
+                                $existing[$key] = DateTime::createFromImmutable( $existing[$key] );
+                            }
                             $value = ($existing[$key] instanceof DateTime || $existing[$key] instanceof DateTimeImmutable) ? $existing[$key]->format('c') : $existing[$key];
                             $num++;
                             $got += intval($value == $event[$key]);
@@ -683,6 +686,9 @@ class libcalendaring_itip
             // For replies we need more metadata
             foreach (array('start', 'end', 'due', 'allday', 'recurrence', 'location') as $key) {
                 if (isset($event[$key])) {
+                    if ($event[$key] instanceof DateTimeImmutable) {
+                        $event[$key] = DateTime::createFromImmutable( $event[$key] );
+                    }
                     $metadata[$key] = ($event[$key] instanceof DateTime || $event[$key] instanceof DateTimeImmutable) ? $event[$key]->format('c') : $event[$key];
                 }
             }

--- a/lib/libcalendaring_recurrence.php
+++ b/lib/libcalendaring_recurrence.php
@@ -128,6 +128,9 @@ class libcalendaring_recurrence
     {
         // recurrence end date is given
         if ($this->recurrence['UNTIL'] instanceof DateTime || $this->recurrence['UNTIL'] instanceof DateTimeImmutable) {
+            if ($this->recurrence['UNTIL'] instanceof DateTimeImmutable) {
+                $this->recurrence['UNTIL'] = DateTime::createFromImmutable( $this->recurrence['UNTIL'] );
+            }
             return $this->recurrence['UNTIL'];
         }
 

--- a/libcalendaring.php
+++ b/libcalendaring.php
@@ -195,7 +195,10 @@ class libcalendaring extends rcube_plugin
             $dt = rcube_utils::anytodatetime($dt);
         }
 
-        if (($dt instanceof DateTime || $dt instanceof DateTimeImmutable) && empty($dt->_dateonly) && !$dateonly) {
+	if (($dt instanceof DateTime || $dt instanceof DateTimeImmutable) && empty($dt->_dateonly) && !$dateonly) {
+	    if ($dt instanceof DateTimeImmutable) {
+                $dt = DateTime::createFromImmutable( $dt );
+            }
             $dt->setTimezone($this->timezone);
         }
 
@@ -506,6 +509,9 @@ class libcalendaring extends rcube_plugin
     {
         return array_map(function($alarm){
             if ($alarm['trigger'] instanceof DateTime || $alarm['trigger'] instanceof DateTimeImmutable) {
+                if ($alarm['trigger'] instanceof DateTimeImmutable) {
+                    $alarm['trigger'] = DateTime::createFromImmutable( $alarm['trigger'] );
+                }
                 $alarm['trigger'] = '@' . $alarm['trigger']->format('U');
             }
             else if ($trigger = libcalendaring::parse_alarm_value($alarm['trigger'])) {
@@ -584,6 +590,9 @@ class libcalendaring extends rcube_plugin
         }
 
         if ($trigger instanceof DateTime || $trigger instanceof DateTimeImmutable) {
+            if ($trigger instanceof DateTimeImmutable) {
+                $trigger = DateTime::createFromImmutable( $trigger );
+            }
             $text .= ' ' . $rcube->gettext(array(
                 'name' => 'libcalendaring.alarmat',
                 'vars' => array('datetime' => $rcube->format_date($trigger))
@@ -664,6 +673,9 @@ class libcalendaring extends rcube_plugin
             $notify_time = null;
 
             if ($alarm['trigger'] instanceof DateTime || $alarm['trigger'] instanceof DateTimeImmutable) {
+                if ($alarm['trigger'] instanceof DateTimeImmutable) {
+                    $alarm['trigger'] = DateTime::createFromImmutable( $alarm['trigger'] );
+                }
                 $notify_time = $alarm['trigger'];
             }
             else if (is_string($alarm['trigger'])) {
@@ -1099,6 +1111,9 @@ class libcalendaring extends rcube_plugin
                 try {
                     $dt = new DateTime($rdate, $tz);
                     if (is_a($start, 'DateTime') || is_a($start, 'DateTimeImmutable'))
+                        if ($start instanceof DateTimeImmutable) {
+                            $start = DateTime::createFromImmutable( $start );
+                        }
                         $dt->setTime($start->format('G'), $start->format('i'));
                     return $dt;
                 }
@@ -1316,6 +1331,9 @@ class libcalendaring extends rcube_plugin
         $instance_date = !empty($event['recurrence_date']) ? $event['recurrence_date'] : $event['start'];
 
         if ($instance_date instanceof DateTime || $instance_date instanceof DateTimeImmutable) {
+            if ($instaance_date instanceof DateTimeImmutable) {
+                $instance_date = DateTime::createFromImmutable( $instance_date );
+            }
             // According to RFC5545 (3.8.4.4) RECURRENCE-ID format should
             // be date/date-time depending on the main event type, not the exception
             if ($allday === null) {
@@ -1465,7 +1483,10 @@ class libcalendaring extends rcube_plugin
             switch ($k) {
             case 'UNTIL':
                 // convert to UTC according to RFC 5545
-                if (is_a($val, 'DateTime') || is_a($ex, 'DateTimeImmutable')) {
+                if (is_a($val, 'DateTime') || is_a($val, 'DateTimeImmutable')) {
+                    if ($val instanceof DateTimeImmutable) {
+                        $val = DateTime::createFromImmutable( $val );
+                    }
                     if (!$allday && empty($val->_dateonly)) {
                         $until = clone $val;
                         $until->setTimezone(new DateTimeZone('UTC'));
@@ -1480,6 +1501,9 @@ class libcalendaring extends rcube_plugin
             case 'EXDATE':
                 foreach ((array)$val as $i => $ex) {
                     if (is_a($ex, 'DateTime') || is_a($ex, 'DateTimeImmutable')) {
+                        if ($ex instanceof DateTimeImmutable) {
+                            $ex = DateTime::createFromImmutable( $ex );
+                        } 
                         $val[$i] = $ex->format('Ymd\THis');
                     }
                 }

--- a/libvcalendar.php
+++ b/libvcalendar.php
@@ -713,7 +713,10 @@ class libvcalendar implements Iterator
         }
 
         // assign current timezone to event start/end
-        if (!empty($event['start']) && ($event['start'] instanceof DateTime || $event['start'] instanceof DateTimeImmutable)) {
+	if (!empty($event['start']) && ($event['start'] instanceof DateTime || $event['start'] instanceof DateTimeImmutable)) {
+            if ($event['start'] instanceof DateTimeImmutable) {
+                $event['start'] = DateTime::createFromImmutable( $event['start'] );
+            }
             $this->_apply_timezone($event['start']);
         }
         else {
@@ -721,6 +724,9 @@ class libvcalendar implements Iterator
         }
 
         if (!empty($event['end']) && ($event['end'] instanceof DateTimeImmutable || $event['end'] instanceof DateTimeImmutable)) {
+            if ($event['end'] instanceof DateTimeImmutable) {
+                $event['end'] = DateTime::createFromImmutable( $event['end'] );
+            }
             $this->_apply_timezone($event['end']);
         }
         else {
@@ -904,6 +910,9 @@ class libvcalendar implements Iterator
             }
         }
         else if ($prop instanceof \DateTime || $prop instanceof \DateTimeImmutable) {
+            if ($prop instanceof DateTimeImmutable) {
+                $prop = DateTime::createFromImmutable( $prop );
+            }
             $dt = $prop;
         }
 
@@ -1088,6 +1097,9 @@ class libvcalendar implements Iterator
 
         // we're exporting a recurrence instance only
         if (!$recurrence_id && !empty($event['recurrence_date']) && ($event['recurrence_date'] instanceof DateTime || $event['recurrence_date'] instanceof DateTimeImmutable)) {
+            if ($recurrence_date instanceof DateTimeImmutable) {
+                $recurrence_date = DateTime::createFromImmutable( $recurrence_date );
+            }
             $recurrence_id = $this->datetime_prop($cal, 'RECURRENCE-ID', $event['recurrence_date'], false, !empty($event['allday']));
             if (!empty($event['thisandfuture'])) {
                 $recurrence_id->add('RANGE', 'THISANDFUTURE');
@@ -1130,6 +1142,9 @@ class libvcalendar implements Iterator
             if (is_array($exdates)) {
                 foreach ($exdates as $exdate) {
                     if ($exdate instanceof DateTime || $exdate instanceof DateTimeImmutable) {
+                        if ($exdate instanceof DateTimeImmutable) {
+                            $exdate = DateTime::createFromImmutable( $exdate );
+                        }
                         $ve->add($this->datetime_prop($cal, 'EXDATE', $exdate));
                     }
                 }
@@ -1195,6 +1210,9 @@ class libvcalendar implements Iterator
                 $va = $cal->createComponent('VALARM');
                 $va->action = $alarm['action'];
                 if ($alarm['trigger'] instanceof DateTime || $alarm['trigger'] instanceof DateTimeImmutable) {
+                    if ($alarm['trigger'] instanceof DateTimeImmutable) {
+                        $alarm['trigger'] = DateTime::createFromImmutable( $alarm['trigger'] );
+                    }
                     $va->add($this->datetime_prop($cal, 'TRIGGER', $alarm['trigger'], true, null, true));
                 }
                 else {
@@ -1237,6 +1255,9 @@ class libvcalendar implements Iterator
                 $va->add('TRIGGER', $val[3]);
             }
             else if ($val[0] instanceof DateTime || $val[0] instanceof DateTimeImmutable) {
+                if ($val[0] instanceof DateTimeImmutable) {
+                    $val[0] = DateTime::createFromImmutable( $val[0] );
+                }
                 $va->add($this->datetime_prop($cal, 'TRIGGER', $val[0], true, null, true));
             }
             $ve->add($va);


### PR DESCRIPTION
@JodliDev, I echo @skug67
(https://github.com/JodliDev/libcalendaring/commit/f79a80179a3976772531bdf13b652806283ecf77#commitcomment-60637522)
in thanking you for creating the fork, its the only working kolab
calendar + caldav I've found.

However, I was having some trouble with timezones with invitations
processed using your fork. When accepting an invitation, it would always
land on my calendar in UTC. I presumed this was due to vobject returning
DateTimeImmutable and the existing code expecting to be able to modify
variables of DateTime. You added OR operators to catch the instances of
DateTimeImmutable where the code previously checked for DateTime, which
got things moving, but didn't handle timezones correctly.

In each place you added an OR for DateTimeImmutable, I added an if for
DateTimeImmutable turning it back into a mutable object, essentially
restoring the previous behavior while also accomodating the new
DateTimeImmutable that vobject spits out.

I tried initially doing it only where necessary, but there were too many
moles to whack so I did them all, and confirm now that timezone handling
is working as expected. There is certainly a better way to do this, but
this works.